### PR TITLE
updating to newest enchant release

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,11 +15,11 @@ pushd $BUILD_DIR
 
 echo "-----> Getting enchant"
 pushd $BUILD_DIR
-curl -s -L -o enchant-1.6.0.tar.gz https://analytics-p-junk.s3.amazonaws.com/enchant-1.6.0-source.tar.gz
-tar -xvzf enchant-1.6.0.tar.gz
+curl -s -L -o enchant-2.2.8.tar.gz https://analytics-p-junk.s3.amazonaws.com/enchant-2.2.8.tar.gz
+tar -xvzf enchant-2.2.8.tar.gz
 
 echo "-----> Building enchant"
-cd enchant-1.6.0
+cd enchant-2.2.8
 ./configure --prefix=$HOME/enchant --with-aspell-prefix=$BUILD_DIR/vendor/aspell
 make
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,6 +20,9 @@ tar -xvzf enchant-2.2.8.tar.gz
 
 echo "-----> Building enchant"
 cd enchant-2.2.8
+
+echo "-----> Hunspell Dictionary Dir"
+echo $BUILD_DIR/vendor/hunspell
 ./configure --prefix=$HOME/enchant --with-aspell-prefix=$BUILD_DIR/vendor/aspell --with-hunspell-prefix=$BUILD_DIR/vendor/hunspell --with-myspell-prefix=$BUILD_DIR/vendor/myspell
 make
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ tar -xvzf enchant-2.2.8.tar.gz
 
 echo "-----> Building enchant"
 cd enchant-2.2.8
-./configure --prefix=$HOME/enchant --with-aspell-prefix=$BUILD_DIR/vendor/aspell
+./configure --prefix=$HOME/enchant --with-aspell-prefix=$BUILD_DIR/vendor/aspell --with-hunspell-prefix=$BUILD_DIR/vendor/hunspell --with-myspell-prefix=$BUILD_DIR/vendor/myspell
 make
 
 echo "-----> Installing enchant"


### PR DESCRIPTION
1.6.0 is VERY old, updating version. pyenchant has also been updated to 3.0.1, and they decoupled from specific enchant versions back in 2.0.0

regarding backwards compatibility, any removed/deprecated features do not look like they affect us